### PR TITLE
chore: replace old partner teams with new ones (Wave 2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*   @googleapis/senseai-eco @googleapis/langchain-bigtable
+*   @googleapis/senseai-eco-team @googleapis/langchain-bigtable-team

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,4 +1,4 @@
 assign_issues:
-  - googleapis/langchain-bigtable
+  - googleapis/langchain-bigtable-team
 assign_prs:
-  - googleapis/langchain-bigtable
+  - googleapis/langchain-bigtable-team

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -41,6 +41,6 @@ branchProtectionRules:
 # Set team access
 permissionRules:
   - team: senseai-eco
-    permission: admin
+    permission: push
   - team: langchain-bigtable
     permission: push

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,5 +9,5 @@
     "repo": "googleapis/langchain-google-bigtable-python",
     "distribution_name": "langchain-google-bigtable",
     "requires_billing": true,
-    "codeowner_team": "@googleapis/senseai-eco"
+    "codeowner_team": "@googleapis/senseai-eco-team"
 }


### PR DESCRIPTION
Replacing old partner teams with new ones as part of Wave 2 migration. b/478003109

As part of this change, we are also removing admin permissions from the repository settings in .github/sync-repo-settings.yaml. Teams that previously had admin access have been removed or updated to have push access.